### PR TITLE
Store people, sessions and preferences after_save

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,7 +7,7 @@ class Event < ApplicationRecord
   has_many :executions
   attr_accessor :import
 
-  before_save :import_data
+  after_create :import_data
 
   private
 


### PR DESCRIPTION
### What

Fix error creating events:


```
6c1d4894-2555-49e2-8475-7625eaa785eb] ActiveRecord::RecordNotSaved (You cannot call create unless the parent is saved):
[6c1d4894-2555-49e2-8475-7625eaa785eb]   
[6c1d4894-2555-49e2-8475-7625eaa785eb] app/models/event.rb:22:in `block (2 levels) in import_data'
[6c1d4894-2555-49e2-8475-7625eaa785eb] app/models/event.rb:22:in `map'
[6c1d4894-2555-49e2-8475-7625eaa785eb] app/models/event.rb:22:in `block in import_data'
[6c1d4894-2555-49e2-8475-7625eaa785eb] app/models/event.rb:19:in `import_data'
[6c1d4894-2555-49e2-8475-7625eaa785eb] app/controllers/events_controller.rb:30:in `block in create'
[6c1d4894-2555-49e2-8475-7625eaa785eb] app/controllers/events_controller.rb:29:in `create'

```